### PR TITLE
Add API endpoint to get full list of registered users

### DIFF
--- a/CSLabs.Api/Controllers/UserController.cs
+++ b/CSLabs.Api/Controllers/UserController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -12,6 +13,7 @@ using FluentEmail.Core;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.EntityFrameworkCore;
 
 namespace CSLabs.Api.Controllers
@@ -63,7 +65,27 @@ namespace CSLabs.Api.Controllers
         {
             return Ok(GetUser());
         }
-        
+
+        [HttpGet]
+        public IActionResult GetUserList()
+        {
+            List<UserInfo> userList = new List<UserInfo>();
+            
+            foreach (User user in DatabaseContext.Users)
+            {
+                UserInfo userInfo = new UserInfo();
+                userInfo.Id = user.Id;
+                userInfo.FirstName = user.FirstName;
+                userInfo.MiddleName = user.MiddleName;
+                userInfo.LastName = user.LastName;
+                userInfo.Email = user.Email;
+                userInfo.Role = user.Role;
+                
+                userList.Add(userInfo);
+            }
+            return Ok(userList);
+        }
+
         [AllowAnonymous]
         [HttpPost("forgot-password/{email}")]
         public async Task<IActionResult> ForgotPassword(string email)

--- a/CSLabs.Api/Models/UserModels/UserInfo.cs
+++ b/CSLabs.Api/Models/UserModels/UserInfo.cs
@@ -1,0 +1,32 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace CSLabs.Api.Models.UserModels
+{
+    public class UserInfo
+    {
+        
+        public int Id { get; set; }
+
+        [Required]
+        [Column(TypeName = "VARCHAR(100)")]
+        public string FirstName { get; set; }
+
+        [Column(TypeName = "VARCHAR(100)")]
+        public string MiddleName { get; set; }
+
+        [Required]
+        [Column(TypeName = "VARCHAR(100)")]
+        public string LastName { get; set; }
+
+        [Column(TypeName = "VARCHAR(45)")]
+        public string Email { get; set; }
+
+        [Required]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public EUserRole Role { get; set; } = EUserRole.Guest;
+        
+    }
+}


### PR DESCRIPTION
This PR will add functionality to the user controller that returns a list of all registered users with one API call. It also implements a new model class that only exposes the necessary information to the API call; we don't wanna be sending everyone's hashed passwords out whenever we want to render a list of users to the admin console. Of course, the information it displays can be altered in the future, but for now it only includes what I expect to be needed for an endpoint like this.