### PR TITLE
Enforce strong passwords coming from requests

### DIFF
--- a/CSLabs.Api/CSLabs.Api.csproj
+++ b/CSLabs.Api/CSLabs.Api.csproj
@@ -42,6 +42,7 @@
     <PackageReference Include="System.ServiceModel.Http" Version="4.7.0" />
     <PackageReference Include="System.ServiceModel.NetTcp" Version="4.7.0" />
     <PackageReference Include="System.ServiceModel.Security" Version="4.7.0" />
+    <PackageReference Include="zxcvbn-core" Version="7.0.92" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CSLabs.Api/Controllers/UserController.cs
+++ b/CSLabs.Api/Controllers/UserController.cs
@@ -124,6 +124,13 @@ namespace CSLabs.Api.Controllers
         [HttpPost("change-password")]
         public async Task<IActionResult> ChangePassword(ChangePasswordRequest request)
         {
+            if (!request.ValidatePasswordStrength())
+            {
+                return BadRequest(new GenericErrorResponse
+                {
+                    Message = "The provided password is not strong enough"
+                });
+            }
             var user = GetUser();
             var newHashedPassword = this._authenticationService.HashPassword(request.NewPassword);
             var hasher = new PasswordHasher<User>();

--- a/CSLabs.Api/RequestModels/ChangePasswordRequest.cs
+++ b/CSLabs.Api/RequestModels/ChangePasswordRequest.cs
@@ -4,5 +4,10 @@ namespace CSLabs.Api.RequestModels
     {
         public string CurrentPassword { get; set; }
         public string NewPassword { get; set; }
+
+        public bool ValidatePasswordStrength()
+        {
+            return Zxcvbn.Core.EvaluatePassword(NewPassword).Score >= 4;
+        }
     }
 }

--- a/CSLabs.Api/RequestModels/RegistrationRequest.cs
+++ b/CSLabs.Api/RequestModels/RegistrationRequest.cs
@@ -1,10 +1,9 @@
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Reflection;
 using CSLabs.Api.Models;
 using CSLabs.Api.Util;
-using Microsoft.EntityFrameworkCore;
+using Zxcvbn;
 
 namespace CSLabs.Api.RequestModels
 {
@@ -35,9 +34,19 @@ namespace CSLabs.Api.RequestModels
                 return new GenericErrorResponse { Message = "The specified email is already in use"};
             }
 
+            if (!ValidatePasswordStrength())
+            {
+                return new GenericErrorResponse { Message = "The provided password is not strong enough" };
+            }
+
             return null;
         }
 
+        public bool ValidatePasswordStrength()
+        {
+            return Zxcvbn.Core.EvaluatePassword(Password).Score >= 4;
+        }
+        
         public bool IsValid(DefaultContext dbContext)
         {
             return Validate(dbContext) == null;

--- a/CSLabs.Tests/UserControllerTest.cs
+++ b/CSLabs.Tests/UserControllerTest.cs
@@ -1,0 +1,43 @@
+﻿using System.Threading.Tasks;
+using CSLabs.Api.RequestModels;
+using NUnit.Framework;
+
+namespace CSLabs.Tests
+{
+    public class UserControllerTest
+    {
+        [Test]
+        public async Task TestPasswordEnforcement()
+        {
+            var registrationRequest = new RegistrationRequest
+            {
+                FirstName = "John",
+                LastName = "Test",
+                ConfirmPassword = "password",
+                Email = "test@test.com",
+                MiddleName = "Test",
+                Password = "password"
+            };
+            
+            Assert.False(registrationRequest.ValidatePasswordStrength());
+
+            registrationRequest.Password = "abc123";
+            Assert.False(registrationRequest.ValidatePasswordStrength());
+            
+            registrationRequest.Password = "trustno1";
+            Assert.False(registrationRequest.ValidatePasswordStrength());
+            
+            registrationRequest.Password = "ncc1701";
+            Assert.False(registrationRequest.ValidatePasswordStrength());
+            
+            registrationRequest.Password = "iloveou!";
+            Assert.False(registrationRequest.ValidatePasswordStrength());
+            
+            registrationRequest.Password = "primetime21";
+            Assert.False(registrationRequest.ValidatePasswordStrength());
+            
+            registrationRequest.Password = "*&OSr8U6TR#uJLxB$V5@7EFMKnbYeV*F";
+            Assert.True(registrationRequest.ValidatePasswordStrength());
+        }
+    }
+}


### PR DESCRIPTION
This PR will enforce strong passwords on the back-end. This was tested with a small unit test written to check password enforcement, as well as altering request data and ensuring that the proper response was received from the back-end.

Password strength enforcement was achieved using [this](https://www.nuget.org/packages/zxcvbn-core/) library, which is a port to .NET of the same library that is used for enforcement on the front-end. So if there is a password that fails the strength enforcement on the front-end, it should also fail the enforcement on the back-end, should the request still get through somehow.

Feel free to suggest test cases for the unit test, and I will gladly add them.