### PR TITLE
Fix Code Smells

### DIFF
--- a/CSLabs.ConsoleUtil/Commands/AddHypervisorCommand.cs
+++ b/CSLabs.ConsoleUtil/Commands/AddHypervisorCommand.cs
@@ -24,8 +24,8 @@ namespace CSLabs.ConsoleUtil.Commands
     
     public class AddHypervisorCommand : AsyncCommand<AddHypervisorOptions>
     {
-        private DefaultContext _context;
-        private string _encryptionKey;
+        private readonly DefaultContext _context;
+        private readonly string _encryptionKey;
         
         public AddHypervisorCommand(DefaultContext context, AppSettings appSettings)
         {

--- a/CSLabs.ConsoleUtil/Commands/AddHypervisorNodeCommand.cs
+++ b/CSLabs.ConsoleUtil/Commands/AddHypervisorNodeCommand.cs
@@ -18,7 +18,7 @@ namespace CSLabs.ConsoleUtil.Commands
     
     public class AddHypervisorNodeCommand : AsyncCommand<AddHypervisorNodeOptions>
     {
-        private DefaultContext _context;
+        private readonly DefaultContext _context;
 
         public AddHypervisorNodeCommand(DefaultContext context)
         {

--- a/CSLabs.ConsoleUtil/Commands/ChangeHypervisorPasswordCommand.cs
+++ b/CSLabs.ConsoleUtil/Commands/ChangeHypervisorPasswordCommand.cs
@@ -19,8 +19,8 @@ namespace CSLabs.ConsoleUtil.Commands
     
     public class ChangeHypervisorPasswordCommand : AsyncCommand<ChangeHypervisorPasswordOptions>
     {
-        private DefaultContext _context;
-        private string _encryptionKey;
+        private readonly DefaultContext _context;
+        private readonly string _encryptionKey;
         
         public ChangeHypervisorPasswordCommand(DefaultContext context, AppSettings appSettings)
         {

--- a/CSLabs.ConsoleUtil/Commands/ChangeUserPasswordCommand.cs
+++ b/CSLabs.ConsoleUtil/Commands/ChangeUserPasswordCommand.cs
@@ -17,8 +17,8 @@ namespace CSLabs.ConsoleUtil.Commands
     }
     public class ChangeUserPasswordCommand : AsyncCommand<ChangeUserPasswordOptions>
     {
-        private DefaultContext _context;
-        private IAuthenticationService _authenticationService;
+        private readonly DefaultContext _context;
+        private readonly IAuthenticationService _authenticationService;
         
         public ChangeUserPasswordCommand(DefaultContext context, IAuthenticationService authenticationService)
         {

--- a/CSLabs.ConsoleUtil/Commands/DecryptCommand.cs
+++ b/CSLabs.ConsoleUtil/Commands/DecryptCommand.cs
@@ -13,7 +13,7 @@ namespace CSLabs.ConsoleUtil.Commands
     }
     public class DecryptCommand : Command<DecryptOptions>
     {
-        private string _encryptionKey;
+        private readonly string _encryptionKey;
         
         public DecryptCommand(AppSettings appSettings)
         {

--- a/CSLabs.ConsoleUtil/Commands/EncryptCommand.cs
+++ b/CSLabs.ConsoleUtil/Commands/EncryptCommand.cs
@@ -13,7 +13,7 @@ namespace CSLabs.ConsoleUtil.Commands
     }
     public class EncryptCommand : Command<EncryptOptions>
     {
-        private string _encryptionKey;
+        private readonly string _encryptionKey;
         
         public EncryptCommand(AppSettings appSettings)
         {

--- a/CSLabs.ConsoleUtil/Commands/ListHypervisors.cs
+++ b/CSLabs.ConsoleUtil/Commands/ListHypervisors.cs
@@ -14,8 +14,10 @@ namespace CSLabs.ConsoleUtil.Commands
     
     public class ListHypervisorsCommand : AsyncCommand<ListHypervisorsOptions>
     {
-        private DefaultContext _context;
-        private string _encryptionKey;
+        private readonly DefaultContext _context;
+        
+        // Do we need this field? It's totally unread, only ever set in the constructor but never used
+        private readonly string _encryptionKey;
         
         public ListHypervisorsCommand(DefaultContext context, AppSettings appSettings)
         {

--- a/CSLabs.ConsoleUtil/Commands/ListHypervisors.cs
+++ b/CSLabs.ConsoleUtil/Commands/ListHypervisors.cs
@@ -15,14 +15,10 @@ namespace CSLabs.ConsoleUtil.Commands
     public class ListHypervisorsCommand : AsyncCommand<ListHypervisorsOptions>
     {
         private readonly DefaultContext _context;
-        
-        // Do we need this field? It's totally unread, only ever set in the constructor but never used
-        private readonly string _encryptionKey;
-        
+
         public ListHypervisorsCommand(DefaultContext context, AppSettings appSettings)
         {
             _context = context;
-            _encryptionKey = appSettings.ProxmoxEncryptionKey;
         }
         
         public override async Task Run(ListHypervisorsOptions options)

--- a/CSLabs.ConsoleUtil/Commands/ListHypervisors.cs
+++ b/CSLabs.ConsoleUtil/Commands/ListHypervisors.cs
@@ -16,7 +16,7 @@ namespace CSLabs.ConsoleUtil.Commands
     {
         private readonly DefaultContext _context;
 
-        public ListHypervisorsCommand(DefaultContext context, AppSettings appSettings)
+        public ListHypervisorsCommand(DefaultContext context)
         {
             _context = context;
         }

--- a/CSLabs.ConsoleUtil/Program.cs
+++ b/CSLabs.ConsoleUtil/Program.cs
@@ -12,10 +12,10 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace CSLabs.ConsoleUtil
 {
-    class Program
+    static class Program
     {
 
-        public static List<Type> Commands = new List<Type>
+        public static readonly List<Type> Commands = new List<Type>
         {
             typeof(AddHypervisorCommand),
             typeof(AddHypervisorNodeCommand),

--- a/CSLabs.Tests/UserControllerTest.cs
+++ b/CSLabs.Tests/UserControllerTest.cs
@@ -7,7 +7,7 @@ namespace CSLabs.Tests
     public class UserControllerTest
     {
         [Test]
-        public async Task TestPasswordEnforcement()
+        public void TestPasswordEnforcement()
         {
             var registrationRequest = new RegistrationRequest
             {


### PR DESCRIPTION
Fixing all of the code smells highlighted by SonarCloud. Very minor stuff for the most part, mostly just making properties readonly that are never changed after instantiation. Also did a minor refactor on a unit test.

Something to note - I did not fix the code smells for this issue highlighted by Jason:
![image](https://user-images.githubusercontent.com/15639276/141692024-3ab29ae3-eec1-4d9d-99c9-79920d25f1ef.png)

Per his advice, this is a non-issue so I created a new quality profile that ignores this rule, so we should no longer see it highlighted.