### PR TITLE
Fix CI action for .NET 6 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - master
       - dev
-      - jc/sonarcloud-dotnet-6
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,33 +12,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.11
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v1
-        with:
-          path: ~\sonar\cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-      - name: Cache SonarCloud scanner
-        id: cache-sonar-scanner
-        uses: actions/cache@v1
-        with:
-          path: .\.sonar\scanner
-          key: ${{ runner.os }}-sonar-scanner
-          restore-keys: ${{ runner.os }}-sonar-scanner
       - name: SonarScanner for .NET 6
-        if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
-        shell: powershell
-        run: |
-          New-Item -Path .\.sonar\scanner -ItemType Directory
-          dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
-      - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - dev
+      - jc/sonarcloud-dotnet-6
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
@@ -31,7 +32,7 @@ jobs:
           path: .\.sonar\scanner
           key: ${{ runner.os }}-sonar-scanner
           restore-keys: ${{ runner.os }}-sonar-scanner
-      - name: Install SonarCloud scanner
+      - name: SonarScanner for .NET 6
         if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
         shell: powershell
         run: |
@@ -41,8 +42,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        shell: powershell
-        run: |
-          .\.sonar\scanner\dotnet-sonarscanner begin /k:"ius-csg_cslabs-backend" /o:"ius-csg" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
-          dotnet build cslabs-backend.sln
-          .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
+        uses: highbyte/sonarscan-dotnet@v2.1.2
+        with:
+          sonarProjectKey: ius-csg_cslabs-backend
+          sonarProjectName: cslabs-backend
+          sonarOrganization: ius-csg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,4 +21,4 @@ jobs:
           sonarProjectKey: ius-csg_cslabs-backend
           sonarProjectName: cslabs-backend
           sonarOrganization: ius-csg
-          dotnetBuildArguments: cslabs-backend.sln
+          dotnetBuildArguments: ./cslabs-backend.sln

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@
 on:
   push:
     branches:
-      - master
+      - main
       - dev
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 11
         uses: actions/setup-java@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: SonarScanner for .NET 6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,3 +25,4 @@ jobs:
           sonarProjectName: cslabs-backend
           sonarOrganization: ius-csg
           dotnetBuildArguments: ./cslabs-backend.sln
+          dotnetDisableTests: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,3 +21,4 @@ jobs:
           sonarProjectKey: ius-csg_cslabs-backend
           sonarProjectName: cslabs-backend
           sonarOrganization: ius-csg
+          dotnetBuildArguments: cslabs-backend.sln


### PR DESCRIPTION
The new action uses a third party action for SonarCloud .NET 6 support which can be found [here](https://github.com/highbyte/sonarscan-dotnet).